### PR TITLE
a workaround for a concurrent modification issue

### DIFF
--- a/ObjScheme/ObjScheme.m
+++ b/ObjScheme/ObjScheme.m
@@ -1255,6 +1255,9 @@ id srfi1_remove( id<ObSProcedure> predicate, ObSCons* list) {
             return ret;
           }
           @catch (NSException *e) {
+            if ( [e.reason rangeOfString:@"mutated while being"].location == NSNotFound ) {
+              @throw;
+            }
             if ( i == 2 ) {
               @throw;
             }


### PR DESCRIPTION
@kiril as discussed, there's an issue here if predicates mutate in a non-idempotent way. But
if someone writes a predicate like that, they should be shot.
